### PR TITLE
Add Stats section to paste viewer

### DIFF
--- a/src/pages/PastePage.tsx
+++ b/src/pages/PastePage.tsx
@@ -2,18 +2,21 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { 
-  Eye, 
-  Star, 
-  GitFork, 
-  Copy, 
-  Download, 
-  Share2, 
+  Eye,
+  Star,
+  GitFork,
+  Copy,
+  Download,
+  Share2,
   Calendar,
   User,
   Code,
   Edit,
   Heart,
   MessageSquare,
+  FileText,
+  List,
+  Database,
   Shield,
   AlertTriangle,
   Key,
@@ -49,6 +52,8 @@ interface PasteData {
   views: number;
   forks: number;
   stars: number;
+  likes?: number;
+  comments?: number;
   tags: string[];
   createdAt: string;
   updatedAt: string;
@@ -264,6 +269,10 @@ export const PastePage: React.FC = () => {
 
   const displayContent = paste.isZeroKnowledge ? decryptedContent : paste.content;
   const canShowContent = !paste.isZeroKnowledge || (paste.isZeroKnowledge && decryptedContent);
+  const charCount = displayContent ? displayContent.length : 0;
+  const lineCount = displayContent ? displayContent.split('\n').length : 0;
+  const sizeBytes = new TextEncoder().encode(displayContent || '').length;
+  const sizeFormatted = sizeBytes < 1024 ? `${sizeBytes} B` : `${(sizeBytes / 1024).toFixed(1)} KB`;
 
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-6xl">
@@ -392,27 +401,41 @@ export const PastePage: React.FC = () => {
             </div>
           </div>
 
-          {/* Stats */}
-          <div className="flex items-center space-x-6 mt-6 pt-6 border-t border-slate-200 dark:border-slate-700">
-            <div className="flex items-center space-x-2 text-slate-600 dark:text-slate-400">
-              <Eye className="h-4 w-4" />
-              <span>{paste.views} views</span>
+          {/* Statistics */}
+          <div className="mt-6 pt-6 border-t border-slate-200 dark:border-slate-700">
+            <h4 className="font-medium text-slate-900 dark:text-white mb-3">Statistics</h4>
+            <div className="flex flex-wrap items-center gap-4 text-slate-600 dark:text-slate-400">
+              <div className="flex items-center space-x-1">
+                <Eye className="h-4 w-4" />
+                <span>{paste.views}</span>
+                <span>Views</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <Heart className="h-4 w-4" />
+                <span>{paste.likes ?? paste.stars}</span>
+                <span>Likes</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <FileText className="h-4 w-4" />
+                <span>{charCount}</span>
+                <span>Characters</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <List className="h-4 w-4" />
+                <span>{lineCount}</span>
+                <span>Lines</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <Database className="h-4 w-4" />
+                <span>{sizeFormatted}</span>
+                <span>Size</span>
+              </div>
+              <div className="flex items-center space-x-1">
+                <MessageSquare className="h-4 w-4" />
+                <span>{paste.comments ?? 0}</span>
+                <span>Comments</span>
+              </div>
             </div>
-            
-            <button className="flex items-center space-x-2 text-slate-600 dark:text-slate-400 hover:text-yellow-500 transition-colors">
-              <Star className="h-4 w-4" />
-              <span>{paste.stars}</span>
-            </button>
-            
-            <button className="flex items-center space-x-2 text-slate-600 dark:text-slate-400 hover:text-blue-500 transition-colors">
-              <GitFork className="h-4 w-4" />
-              <span>{paste.forks}</span>
-            </button>
-            
-            <button className="flex items-center space-x-2 text-slate-600 dark:text-slate-400 hover:text-red-500 transition-colors">
-              <Heart className="h-4 w-4" />
-              <span>Like</span>
-            </button>
           </div>
 
           {/* Tags */}


### PR DESCRIPTION
## Summary
- show counts for views, likes, characters, lines, size and comments when viewing a paste

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539e84c4d08321b6c74db9a095b971