### PR TITLE
Add mutual exclusivity for zero-knowledge encryption

### DIFF
--- a/src/pages/CreatePastePage.tsx
+++ b/src/pages/CreatePastePage.tsx
@@ -296,8 +296,10 @@ export const CreatePastePage: React.FC = () => {
   // Handle zero-knowledge toggle
   const handleZeroKnowledgeToggle = (checked: boolean) => {
     setIsZeroKnowledge(checked);
-    
+
     if (checked) {
+      // Disable burn-after-read when zero-knowledge is enabled
+      setBurnAfterRead(false);
       // Zero-knowledge pastes are automatically unlisted
       setVisibility('unlisted');
       
@@ -517,6 +519,7 @@ export const CreatePastePage: React.FC = () => {
                 type="checkbox"
                 checked={burnAfterRead}
                 onChange={(e) => handleBurnAfterReadToggle(e.target.checked)}
+                disabled={isZeroKnowledge}
                 className="h-4 w-4 text-red-600 focus:ring-red-500 border-slate-300 dark:border-slate-600 rounded"
               />
               <label htmlFor="burn-after-read" className="text-sm font-medium text-slate-700 dark:text-slate-300">


### PR DESCRIPTION
## Summary
- disable `Burn After Read` checkbox while zero‑knowledge encryption is active
- uncheck `Burn After Read` when enabling zero‑knowledge encryption

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' / many lint errors)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6854610ce8f08321a0d6ed5f408c6838