### PR TITLE
Enable session cookie for paste verification

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -290,7 +290,8 @@ class ApiService {
   async verifyPastePassword(id: string, password: string) {
     return this.makeRequest(`${API_BASE_URL}/pastes/${id}/verify`, {
       method: 'POST',
-      body: JSON.stringify({ password })
+      body: JSON.stringify({ password }),
+      credentials: 'include'
     });
   }
 


### PR DESCRIPTION
## Summary
- send credentials along when verifying paste passwords to ensure backend session cookies are stored

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3608864832182eb648244a1b7d3