### PR TITLE
Implement paste token persistence

### DIFF
--- a/src/pages/PastePage.tsx
+++ b/src/pages/PastePage.tsx
@@ -97,7 +97,6 @@ export const PastePage: React.FC = () => {
   const [relatedPastes, setRelatedPastes] = useState<RelatedPaste[]>([]);
   const [passwordRequired, setPasswordRequired] = useState(false);
   const [password, setPassword] = useState('');
-  const [authToken, setAuthToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (id) {
@@ -132,7 +131,9 @@ export const PastePage: React.FC = () => {
     setError(null);
     
     try {
-      const data = await apiService.getPaste(id, authToken || undefined);
+      const { pasteAccessTokens } = useAppStore.getState();
+      const token = pasteAccessTokens[id];
+      const data = await apiService.getPaste(id, token);
       setPaste(data);
       setPasswordRequired(false);
     } catch (err) {
@@ -302,11 +303,12 @@ export const PastePage: React.FC = () => {
           <button
             onClick={async () => {
               try {
+                const { setPasteAccessToken } = useAppStore.getState();
                 const response = await apiService.verifyPastePassword(id!, password);
-                setAuthToken(response.token);
+                setPasteAccessToken(id!, response.token);
                 setPassword('');
                 setPasswordRequired(false);
-                await fetchPaste();
+                navigate(`/paste/${id}`);
               } catch (err) {
                 toast.error('Invalid password');
               }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -11,6 +11,8 @@ interface AppState {
   isLoading: boolean;
   apiError: string | null;
   backendStatus: 'unknown' | 'healthy' | 'sleeping' | 'error';
+  pasteAccessTokens: Record<string, string>;
+  setPasteAccessToken: (pasteId: string, token: string) => void;
   
   // Pastes
   loadRecentPastes: () => Promise<void>;
@@ -46,6 +48,15 @@ export const useAppStore = create<AppState>((set, get) => ({
   isLoading: false,
   apiError: null,
   backendStatus: 'unknown',
+  pasteAccessTokens: {},
+  setPasteAccessToken: (pasteId: string, token: string) => {
+    set((state) => ({
+      pasteAccessTokens: {
+        ...state.pasteAccessTokens,
+        [pasteId]: token,
+      },
+    }));
+  },
 
   loadRecentPastes: async () => {
     set({ isLoading: true, apiError: null });


### PR DESCRIPTION
## Summary
- add pasteAccessTokens to app store
- fetch paste data with token from store
- store token in store after password verification

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855f3c100a48321b13fef8fa901fa11