### PR TITLE
Fix zero-knowledge banner detection

### DIFF
--- a/src/pages/PastePage.tsx
+++ b/src/pages/PastePage.tsx
@@ -95,11 +95,19 @@ export const PastePage: React.FC = () => {
   const [relatedPastes, setRelatedPastes] = useState<RelatedPaste[]>([]);
   const [passwordRequired, setPasswordRequired] = useState(false);
   const [password, setPassword] = useState('');
-  const [hasDecryptionKey] = useState(() =>
-    typeof window !== 'undefined' &&
-    window.location.hash &&
-    window.location.hash.startsWith('#key=')
-  );
+  const [hasDecryptionKey, setHasDecryptionKey] = useState(false);
+
+  useEffect(() => {
+    const checkForKey = () => {
+      const hash = window.location.hash || '';
+      setHasDecryptionKey(hash.startsWith('#key='));
+    };
+
+    checkForKey();
+    window.addEventListener('hashchange', checkForKey);
+
+    return () => window.removeEventListener('hashchange', checkForKey);
+  }, []);
 
   const { pasteAccessTokens, setPasteAccessToken } = useAppStore();
 


### PR DESCRIPTION
Summary

Switched from a static initialization to dynamic detection of the #key hash by adding a new useEffect hook so the banner correctly appears when the encryption key is present in the URL