### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -129,7 +129,7 @@ class ApiService {
       
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`❌ Request failed for ${url}:`, message);
+      console.error('❌ Request failed for %s:', url, message);
       if (error instanceof Error && error.stack) {
         console.debug(error.stack);
       }


### PR DESCRIPTION
Potential fix for [https://github.com/jeremystevens/pb2-render/security/code-scanning/3](https://github.com/jeremystevens/pb2-render/security/code-scanning/3)

To fix the issue, the untrusted `id` parameter should not be directly interpolated into the log message. Instead, the `%s` format specifier should be used, and the `id` should be passed as a separate argument to the logging function. This ensures that the log message is formatted correctly regardless of the content of `id`.

**Steps to implement the fix:**
1. Update the `console.error` statement on line 132 in `src/services/api.ts` to use the `%s` format specifier for the `url` parameter.
2. Pass the `url` as a separate argument to the `console.error` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
