### PR TITLE
Improve profile picture handling and edit UI

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -100,9 +100,9 @@ export const Header: React.FC = () => {
                     onClick={() => setIsProfileOpen(!isProfileOpen)}
                     className="flex items-center space-x-2 p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
                   >
-                    {user?.avatar ? (
+                    {user?.profile_picture || user?.avatar ? (
                       <img
-                        src={user.avatar}
+                        src={user.profile_picture || user.avatar}
                         alt={user.username}
                         className="h-8 w-8 rounded-full object-cover border-2 border-slate-200 dark:border-slate-600"
                       />

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -146,9 +146,9 @@ export const AdminPage: React.FC = () => {
           <div className="space-y-4">
             {recentUsers.map(user => (
               <div key={user.id} className="flex items-center space-x-3">
-                {user.avatar ? (
+                {user.profile_picture || user.avatar ? (
                   <img
-                    src={user.avatar}
+                    src={user.profile_picture || user.avatar}
                     alt={user.username}
                     className="w-10 h-10 rounded-full object-cover"
                   />
@@ -251,9 +251,9 @@ export const AdminPage: React.FC = () => {
                 <tr key={user.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/50">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center space-x-3">
-                      {user.avatar ? (
+                      {user.profile_picture || user.avatar ? (
                         <img
-                          src={user.avatar}
+                          src={user.profile_picture || user.avatar}
                           alt={user.username}
                           className="w-10 h-10 rounded-full object-cover"
                         />

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -18,6 +18,7 @@ export const EditProfile: React.FC = () => {
   const [tagline, setTagline] = useState('');
   const [website, setWebsite] = useState('');
   const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -35,7 +36,9 @@ export const EditProfile: React.FC = () => {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      setFile(e.target.files[0]);
+      const selected = e.target.files[0];
+      setFile(selected);
+      setPreviewUrl(URL.createObjectURL(selected));
     }
   };
 
@@ -47,8 +50,13 @@ export const EditProfile: React.FC = () => {
       profilePicture = await toBase64(file);
     }
     try {
-      await apiService.updateProfile(user.id, { tagline, website, profilePicture });
-      updateProfile({ tagline, website, avatar: profilePicture ? '' : undefined });
+      const result = await apiService.updateProfile(user.id, { tagline, website, profilePicture });
+      updateProfile({
+        tagline,
+        website,
+        avatar: result.profilePicture ?? user.avatar,
+        profile_picture: result.profilePicture ?? user.profile_picture,
+      });
       navigate(`/profile/${user.username}`);
     } catch (err) {
       console.error('Failed to update profile', err);
@@ -56,21 +64,26 @@ export const EditProfile: React.FC = () => {
   };
 
   return (
-    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-xl">
-      <form onSubmit={handleSubmit} className="space-y-4 bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
-        <div>
-          <label className="block mb-1 font-medium">Profile Picture</label>
-          <input type="file" accept="image/png, image/jpeg, image/gif" onChange={handleFileChange} />
+    <div className="edit-profile-card bg-slate-800 p-6 rounded-lg shadow-md max-w-md mx-auto mt-8 text-white">
+      <h2 className="text-xl font-semibold mb-4">Edit Your Profile</h2>
+
+      {previewUrl && (
+        <div className="w-24 h-24 rounded-full overflow-hidden mb-4">
+          <img src={previewUrl} className="object-cover w-full h-full" alt="Profile preview" />
         </div>
-        <div>
-          <label className="block mb-1 font-medium">Tagline</label>
-          <input type="text" maxLength={100} value={tagline} onChange={e => setTagline(e.target.value)} className="w-full border px-3 py-2 rounded" />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Website</label>
-          <input type="url" value={website} onChange={e => setWebsite(e.target.value)} className="w-full border px-3 py-2 rounded" />
-        </div>
-        <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded">Save Changes</button>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <label className="block mb-2 font-medium">Profile Picture</label>
+        <input type="file" accept="image/*" onChange={handleFileChange} className="mb-4 bg-slate-700 p-2 rounded" />
+
+        <label className="block mb-2 font-medium">Tagline</label>
+        <input type="text" maxLength={100} value={tagline} onChange={e => setTagline(e.target.value)} className="w-full p-2 mb-4 rounded bg-slate-700" />
+
+        <label className="block mb-2 font-medium">Website</label>
+        <input type="url" value={website} onChange={e => setWebsite(e.target.value)} className="w-full p-2 mb-6 rounded bg-slate-700" />
+
+        <button type="submit" className="w-full bg-violet-600 hover:bg-violet-700 text-white p-2 rounded">Save Changes</button>
       </form>
     </div>
   );

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -30,6 +30,7 @@ interface ProfileUser {
   username: string;
   email?: string;
   avatar?: string;
+  profile_picture?: string;
   bio?: string;
   website?: string;
   location?: string;
@@ -76,6 +77,7 @@ export const ProfilePage: React.FC = () => {
           username: currentUser.username,
           email: currentUser.email,
           avatar: currentUser.avatar,
+          profile_picture: currentUser.profile_picture,
           bio: currentUser.bio,
           website: currentUser.website,
           location: currentUser.location,
@@ -116,6 +118,7 @@ export const ProfilePage: React.FC = () => {
               id: localUser.id,
               username: localUser.username,
               avatar: localUser.avatar,
+              profile_picture: localUser.profile_picture,
               bio: localUser.bio,
               website: localUser.website,
               location: localUser.location,
@@ -197,9 +200,9 @@ export const ProfilePage: React.FC = () => {
           <div className="px-6 pb-6">
             <div className="flex flex-col sm:flex-row sm:items-end sm:space-x-6 -mt-16">
               <div className="relative">
-                {profileUser.avatar ? (
+                {profileUser.profile_picture || profileUser.avatar ? (
                   <img
-                    src={profileUser.avatar}
+                    src={profileUser.profile_picture || profileUser.avatar}
                     alt={profileUser.username}
                     className="w-32 h-32 rounded-full border-4 border-white dark:border-slate-800 object-cover"
                   />

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -85,9 +85,9 @@ export const SettingsPage: React.FC = () => {
               <div className="space-y-4">
                 <div className="flex items-center space-x-6">
                   <div className="relative">
-                    {user?.avatar ? (
+                    {user?.profile_picture || user?.avatar ? (
                       <img
-                        src={user.avatar}
+                        src={user.profile_picture || user.avatar}
                         alt={user.username}
                         className="w-20 h-20 rounded-full object-cover"
                       />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export interface User {
   username: string;
   email: string;
   avatar?: string;
+  profile_picture?: string;
   bio?: string;
   tagline?: string;
   website?: string;


### PR DESCRIPTION
## Summary
- add previewUrl and styled card layout to EditProfile page
- store returned avatar path when saving profile
- render profile_picture or avatar everywhere avatars are shown
- extend User type with `profile_picture`

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856fca940f8832190fc924c76d59b33