### PR TITLE
Add profile picture preview & avatar fixes

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -59,7 +59,8 @@ router.post('/register', async (req, res) => {
         pasteCount: 0,
         projectCount: 0,
         tagline: user.tagline,
-        avatar: user.profile_picture
+        avatar: user.profile_picture,
+        profilePicture: user.profile_picture
       },
       token
     });
@@ -118,6 +119,7 @@ router.post('/login', async (req, res) => {
         username: user.username,
         email: user.email,
         avatar: user.profile_picture || user.avatar_url,
+        profilePicture: user.profile_picture || null,
         bio: user.bio,
         tagline: user.tagline,
         website: user.website,
@@ -174,6 +176,7 @@ router.get('/verify', async (req, res) => {
         username: user.username,
         email: user.email,
         avatar: user.profile_picture || user.avatar_url,
+        profilePicture: user.profile_picture || null,
         bio: user.bio,
         tagline: user.tagline,
         website: user.website,

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -30,7 +30,8 @@ router.get('/:username', async (req, res) => {
     res.json({
       id: user.id.toString(),
       username: user.username,
-      avatar: user.avatar_url,
+      avatar: user.profile_picture || user.avatar_url,
+      profilePicture: user.profile_picture || null,
       bio: user.bio,
       website: user.website,
       location: user.location,

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -20,6 +20,8 @@ import { useAuthStore } from '../../store/authStore';
 import { useThemeStore } from '../../store/themeStore';
 import { motion, AnimatePresence } from 'framer-motion';
 
+const defaultAvatar = '/default-avatar.png';
+
 export const Header: React.FC = () => {
   const { user, isAuthenticated, logout } = useAuthStore();
   const { theme, toggleTheme } = useThemeStore();
@@ -100,22 +102,11 @@ export const Header: React.FC = () => {
                     onClick={() => setIsProfileOpen(!isProfileOpen)}
                     className="flex items-center space-x-2 p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
                   >
-                    {user?.profile_picture || user?.avatar ? (
-                      <img
-                        src={user.profile_picture || user.avatar}
-                        alt={user.username}
-                        className="h-8 w-8 rounded-full object-cover border-2 border-slate-200 dark:border-slate-600"
-                      />
-                    ) : (
-                      <div className="flex items-center space-x-2">
-                        <div className="h-8 w-8 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-full flex items-center justify-center">
-                          <User className="h-4 w-4 text-white" />
-                        </div>
-                        <span className="hidden sm:block text-sm font-medium text-slate-700 dark:text-slate-200">
-                          {user?.username}
-                        </span>
-                      </div>
-                    )}
+                    <img
+                      src={user?.profilePicture || user?.profile_picture || user?.avatar || defaultAvatar}
+                      alt={user?.username}
+                      className="h-8 w-8 rounded-full object-cover border-2 border-slate-200 dark:border-slate-600"
+                    />
                   </button>
 
                   <AnimatePresence>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -26,6 +26,8 @@ import { useAppStore } from '../store/appStore';
 import { mockUsers } from '../data/mockData';
 import { formatDistanceToNow } from 'date-fns';
 
+const defaultAvatar = '/default-avatar.png';
+
 export const AdminPage: React.FC = () => {
   const { pastes, projects, issues, notifications } = useAppStore();
   const [activeTab, setActiveTab] = useState('overview');
@@ -146,17 +148,11 @@ export const AdminPage: React.FC = () => {
           <div className="space-y-4">
             {recentUsers.map(user => (
               <div key={user.id} className="flex items-center space-x-3">
-                {user.profile_picture || user.avatar ? (
-                  <img
-                    src={user.profile_picture || user.avatar}
-                    alt={user.username}
-                    className="w-10 h-10 rounded-full object-cover"
-                  />
-                ) : (
-                  <div className="w-10 h-10 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-full flex items-center justify-center">
-                    <Users className="h-5 w-5 text-white" />
-                  </div>
-                )}
+                <img
+                  src={user.profilePicture || user.profile_picture || user.avatar || defaultAvatar}
+                  alt={user.username}
+                  className="w-10 h-10 rounded-full object-cover"
+                />
                 <div className="flex-1">
                   <div className="font-medium text-slate-900 dark:text-white">
                     {user.username}
@@ -251,17 +247,11 @@ export const AdminPage: React.FC = () => {
                 <tr key={user.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/50">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center space-x-3">
-                      {user.profile_picture || user.avatar ? (
-                        <img
-                          src={user.profile_picture || user.avatar}
-                          alt={user.username}
-                          className="w-10 h-10 rounded-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-10 h-10 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-full flex items-center justify-center">
-                          <Users className="h-5 w-5 text-white" />
-                        </div>
-                      )}
+                      <img
+                        src={user.profilePicture || user.profile_picture || user.avatar || defaultAvatar}
+                        alt={user.username}
+                        className="w-10 h-10 rounded-full object-cover"
+                      />
                       <div>
                         <div className="font-medium text-slate-900 dark:text-white">
                           {user.username}

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -14,11 +14,13 @@ const toBase64 = (file: File): Promise<string> => {
 
 export const EditProfile: React.FC = () => {
   const { user, updateProfile } = useAuthStore();
+  const defaultAvatar = '/default-avatar.png';
   const navigate = useNavigate();
   const [tagline, setTagline] = useState('');
   const [website, setWebsite] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [currentPicture, setCurrentPicture] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -27,6 +29,7 @@ export const EditProfile: React.FC = () => {
         const data = await apiService.getEditableProfile(user.id);
         setTagline(data.tagline || '');
         setWebsite(data.website || '');
+        setCurrentPicture(data.profilePicture || null);
       } catch (err) {
         console.error('Failed to load profile', err);
       }
@@ -56,6 +59,7 @@ export const EditProfile: React.FC = () => {
         website,
         avatar: result.profilePicture ?? user.avatar,
         profile_picture: result.profilePicture ?? user.profile_picture,
+        profilePicture: result.profilePicture ?? user.profilePicture,
       });
       navigate(`/profile/${user.username}`);
     } catch (err) {
@@ -67,9 +71,13 @@ export const EditProfile: React.FC = () => {
     <div className="edit-profile-card bg-slate-800 p-6 rounded-lg shadow-md max-w-md mx-auto mt-8 text-white">
       <h2 className="text-xl font-semibold mb-4">Edit Your Profile</h2>
 
-      {previewUrl && (
-        <div className="w-24 h-24 rounded-full overflow-hidden mb-4">
-          <img src={previewUrl} className="object-cover w-full h-full" alt="Profile preview" />
+      {(previewUrl || currentPicture) && (
+        <div className="w-24 h-24 rounded-full overflow-hidden mb-4 mx-auto">
+          <img
+            src={previewUrl || currentPicture || defaultAvatar}
+            className="object-cover w-full h-full"
+            alt="Current Avatar"
+          />
         </div>
       )}
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -18,6 +18,8 @@ import {
 import { useAppStore } from '../store/appStore';
 import { useAuthStore } from '../store/authStore';
 import { apiService } from '../services/api';
+
+const defaultAvatar = '/default-avatar.png';
 import { UserAchievements, Achievement } from '../components/Achievements/UserAchievements';
 import { PasteCard } from '../components/Paste/PasteCard';
 import { ProfileSummary as ProfileSummaryComponent } from '../components/Profile/ProfileSummary';
@@ -31,6 +33,7 @@ interface ProfileUser {
   email?: string;
   avatar?: string;
   profile_picture?: string;
+  profilePicture?: string;
   bio?: string;
   website?: string;
   location?: string;
@@ -78,6 +81,7 @@ export const ProfilePage: React.FC = () => {
           email: currentUser.email,
           avatar: currentUser.avatar,
           profile_picture: currentUser.profile_picture,
+          profilePicture: currentUser.profilePicture,
           bio: currentUser.bio,
           website: currentUser.website,
           location: currentUser.location,
@@ -119,6 +123,7 @@ export const ProfilePage: React.FC = () => {
               username: localUser.username,
               avatar: localUser.avatar,
               profile_picture: localUser.profile_picture,
+              profilePicture: localUser.profilePicture,
               bio: localUser.bio,
               website: localUser.website,
               location: localUser.location,
@@ -200,17 +205,11 @@ export const ProfilePage: React.FC = () => {
           <div className="px-6 pb-6">
             <div className="flex flex-col sm:flex-row sm:items-end sm:space-x-6 -mt-16">
               <div className="relative">
-                {profileUser.profile_picture || profileUser.avatar ? (
-                  <img
-                    src={profileUser.profile_picture || profileUser.avatar}
-                    alt={profileUser.username}
-                    className="w-32 h-32 rounded-full border-4 border-white dark:border-slate-800 object-cover"
-                  />
-                ) : (
-                  <div className="w-32 h-32 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-full border-4 border-white dark:border-slate-800 flex items-center justify-center">
-                    <User className="h-16 w-16 text-white" />
-                  </div>
-                )}
+                <img
+                  src={profileUser.profilePicture || profileUser.profile_picture || profileUser.avatar || defaultAvatar}
+                  alt={profileUser.username}
+                  className="w-32 h-32 rounded-full border-4 border-white dark:border-slate-800 object-cover"
+                />
               </div>
               
               <div className="flex-1 mt-4 sm:mt-0">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -85,17 +85,11 @@ export const SettingsPage: React.FC = () => {
               <div className="space-y-4">
                 <div className="flex items-center space-x-6">
                   <div className="relative">
-                    {user?.profile_picture || user?.avatar ? (
-                      <img
-                        src={user.profile_picture || user.avatar}
-                        alt={user.username}
-                        className="w-20 h-20 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="w-20 h-20 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-full flex items-center justify-center">
-                        <User className="h-8 w-8 text-white" />
-                      </div>
-                    )}
+                    <img
+                      src={user?.profilePicture || user?.profile_picture || user?.avatar || '/default-avatar.png'}
+                      alt={user?.username}
+                      className="w-20 h-20 rounded-full object-cover"
+                    />
                     <button className="absolute bottom-0 right-0 p-2 bg-white dark:bg-slate-800 rounded-full border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors">
                       <Upload className="h-4 w-4 text-slate-600 dark:text-slate-400" />
                     </button>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,8 @@ export interface User {
   username: string;
   email: string;
   avatar?: string;
-  profile_picture?: string;
+  profile_picture?: string; // legacy field
+  profilePicture?: string;
   bio?: string;
   tagline?: string;
   website?: string;


### PR DESCRIPTION
## Summary
- add default avatar asset and expose from public folder
- update server auth/profile routes to send `profilePicture`
- modernize EditProfile with existing picture preview
- fix avatar rendering across app using `user.profilePicture`
- remove placeholder avatar image

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint errors)*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_685702a5708483218a0c0f2d8cac9c1d