### PR TITLE
Implement user collections API

### DIFF
--- a/server/database/connection.js
+++ b/server/database/connection.js
@@ -172,6 +172,29 @@ export async function initializeDatabase() {
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
     `);
+
+    // Create collections tables for organizing pastes
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS collections (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        is_public BOOLEAN DEFAULT TRUE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      )
+    `);
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS collection_pastes (
+        id SERIAL PRIMARY KEY,
+        collection_id INTEGER REFERENCES collections(id) ON DELETE CASCADE,
+        paste_id INTEGER REFERENCES pastes(id) ON DELETE CASCADE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        UNIQUE(collection_id, paste_id)
+      )
+    `);
     
     // Create ai_summaries table
     await client.query(`

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -106,6 +106,34 @@ router.get('/:username/pastes', async (req, res) => {
   }
 });
 
+// Get collections created by a user by user ID
+router.get('/:userId/collections', async (req, res) => {
+  const { userId } = req.params;
+  try {
+    const result = await pool.query(
+      `SELECT id, name, description, is_public, created_at, updated_at
+       FROM collections WHERE user_id = $1 ORDER BY created_at DESC`,
+      [userId]
+    );
+
+    const collections = result.rows.map(row => ({
+      id: row.id.toString(),
+      name: row.name,
+      description: row.description,
+      author: { id: userId },
+      pastes: [],
+      isPublic: row.is_public,
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    }));
+
+    res.json(collections);
+  } catch (err) {
+    console.error('Error fetching user collections:', err);
+    res.status(500).json({ error: 'Failed to fetch user collections' });
+  }
+});
+
 // Profile summary for user by ID
 router.get('/:userId/profile-summary', async (req, res) => {
   try {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -73,6 +73,10 @@ export const ProfilePage: React.FC = () => {
   
   const isOwnProfile = currentUser?.username === username;
 
+  const resetCollectionsState = () => {
+    setCollections([]);
+  };
+
   useEffect(() => {
     if (username) {
       fetchUserProfile();
@@ -111,7 +115,7 @@ export const ProfilePage: React.FC = () => {
         const filteredPastes = pastes.filter(p => p.author.username === username && p.isPublic);
         setUserPastes(filteredPastes);
         const userCollections = await apiService.getUserCollections(currentUser.id);
-        setCollections(userCollections);
+        setCollections(userCollections || []);
         const ach = await apiService.getUserAchievements(currentUser.id);
         setAchievements(ach);
         const summary = await apiService.getProfileSummary(currentUser.id);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -318,6 +318,10 @@ class ApiService {
     return this.makeRequest(`${API_BASE_URL}/users/${userId}/achievements`);
   }
 
+  async getUserCollections(userId: string) {
+    return this.makeRequest(`${API_BASE_URL}/users/${userId}/collections`);
+  }
+
   async getProfileSummary(userId: string) {
     return this.makeRequest(`${API_BASE_URL}/users/${userId}/profile-summary`);
   }


### PR DESCRIPTION
## Summary
- add collections tables to DB initialization
- expose `/api/users/:userId/collections` route
- call `getUserCollections` from frontend API service
- reset collection state and handle empty collections on profile page

## Testing
- `npm run lint` *(fails: cannot fix all eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685721d48244832187a0cce7999b3d16