### PR TITLE
Implement settings profile editing

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -188,7 +188,8 @@ export const SettingsPage: React.FC = () => {
                     <input
                       type="text"
                       value={profileData.username}
-                      readOnly
+                      disabled
+                      aria-disabled="true"
                       className="w-full px-4 py-3 bg-slate-50 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 rounded-lg opacity-70 cursor-not-allowed"
                     />
                   </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -89,12 +89,9 @@ export const SettingsPage: React.FC = () => {
       const result = await apiService.updateProfile(user.id, formData);
       updateProfile({
         bio: result.bio,
-        tagline: result.bio,
         website: result.website,
         location: result.location,
-        avatar: result.profilePicture ?? user.avatar,
-        profile_picture: result.profilePicture ?? user.profile_picture,
-        profilePicture: result.profilePicture ?? user.profilePicture
+        profilePicture: result.profilePicture ?? user.profilePicture ?? user.avatar
       });
       setAvatarFile(null);
       toast.success('Profile updated successfully!');

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -108,6 +108,9 @@ export const SettingsPage: React.FC = () => {
     if (e.target.files && e.target.files[0]) {
       const selected = e.target.files[0];
       setAvatarFile(selected);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
       setPreviewUrl(URL.createObjectURL(selected));
     }
   };


### PR DESCRIPTION
## Summary
- extend profile API to support bio/location updates
- load editable profile info on Settings page
- allow users to upload avatars with preview
- disable username & email editing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68575324380c832189650d7bb0591406