### PR TITLE
Add password update API and frontend call

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import bcrypt from 'bcrypt';
 import pool from '../database/connection.js';
 import { authenticateToken } from '../middleware/auth.js';
 import upload from '../middleware/upload.js';
@@ -267,6 +268,60 @@ router.put('/:userId/profile', authenticateToken, upload.single('avatar'), async
   } catch (error) {
     console.error('Error updating profile:', error);
     res.status(500).json({ error: 'Failed to update profile' });
+  }
+});
+
+// Update user password
+router.put('/:userId/password', authenticateToken, async (req, res) => {
+  try {
+    const { userId } = req.params;
+    if (parseInt(userId) !== req.user.id && !req.user.is_admin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const { currentPassword, newPassword } = req.body;
+
+    if (!currentPassword || !newPassword) {
+      return res
+        .status(400)
+        .json({ error: 'Current and new password are required' });
+    }
+
+    if (newPassword.length < 6) {
+      return res
+        .status(400)
+        .json({ error: 'Password must be at least 6 characters long' });
+    }
+
+    const result = await pool.query(
+      'SELECT password_hash FROM users WHERE id = $1',
+      [userId]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const valid = await bcrypt.compare(
+      currentPassword,
+      result.rows[0].password_hash
+    );
+
+    if (!valid) {
+      return res.status(401).json({ error: 'Incorrect current password' });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+
+    await pool.query(
+      'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
+      [hashed, userId]
+    );
+
+    res.json({ message: 'Password updated successfully' });
+  } catch (error) {
+    console.error('Error updating password:', error);
+    res.status(500).json({ error: 'Failed to update password' });
   }
 });
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -116,24 +116,39 @@ export const SettingsPage: React.FC = () => {
     fileInputRef.current?.click();
   };
 
-  const handlePasswordChange = () => {
+  const handlePasswordChange = async () => {
+    if (!user) return;
+
     if (passwordData.newPassword !== passwordData.confirmPassword) {
       toast.error('New passwords do not match');
       return;
     }
-    
+
     if (passwordData.newPassword.length < 6) {
       toast.error('Password must be at least 6 characters');
       return;
     }
 
-    // Mock password change
-    toast.success('Password changed successfully!');
-    setPasswordData({
-      currentPassword: '',
-      newPassword: '',
-      confirmPassword: ''
-    });
+    try {
+      await apiService.updatePassword(user.id, {
+        currentPassword: passwordData.currentPassword,
+        newPassword: passwordData.newPassword
+      });
+
+      toast.success('Password changed successfully!');
+      setPasswordData({
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: ''
+      });
+    } catch (err: unknown) {
+      console.error('Failed to change password', err);
+      const message =
+        typeof err === 'object' && err && 'error' in err
+          ? (err as { error?: string }).error
+          : undefined;
+      toast.error(message || 'Failed to change password');
+    }
   };
 
   const renderTabContent = () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -337,6 +337,13 @@ class ApiService {
     });
   }
 
+  async updatePassword(userId: string, data: { currentPassword: string; newPassword: string }) {
+    return this.makeRequest(`${API_BASE_URL}/users/${userId}/password`, {
+      method: 'PUT',
+      body: JSON.stringify(data)
+    });
+  }
+
   async getAchievements(userId?: string) {
     const query = userId ? `?userId=${userId}` : '';
     return this.makeRequest(`${API_BASE_URL}/achievements${query}`);


### PR DESCRIPTION
## Summary
- implement password update route on backend
- expose `updatePassword` in API service
- hook up password change form in settings to call new API

## Testing
- `npm run lint` *(fails: 57 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68575881ceec8321b0b9b2f13883282d