### PR TITLE
Fix Prism rendering

### DIFF
--- a/src/pages/ViewPastePage.tsx
+++ b/src/pages/ViewPastePage.tsx
@@ -120,11 +120,9 @@ const ViewPastePage: React.FC = () => {
     }
   }, [id]);
 
-  const displayContent = paste?.content || '';
-
   useEffect(() => {
     Prism.highlightAll();
-  }, [displayContent]);
+  }, [paste]);
 
   const fetchPaste = async () => {
     try {
@@ -414,9 +412,9 @@ const ViewPastePage: React.FC = () => {
               </div>
               
               <div className="overflow-x-auto">
-                <pre className={`!bg-transparent !m-0 !p-4 line-numbers language-${sanitizeLanguage(paste.syntax_language)}`}> 
+                <pre className={`line-numbers language-${sanitizeLanguage(paste.syntax_language)}`}>
                   <code className={`language-${sanitizeLanguage(paste.syntax_language)}`}>
-                    {displayContent}
+                    {paste.content}
                   </code>
                 </pre>
               </div>


### PR DESCRIPTION
## Summary
- adjust highlightAll useEffect to run after paste loads
- simplify code block rendering for Prism compatibility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685854ae1ef08321b0eb53c098bdda7c